### PR TITLE
Get curl 7.54 built with nghttp2 by hook or by crook.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 env:
   global:
   - REPO_DIR=rasterio
-  - BUILD_COMMIT=1.0.14
+  - BUILD_COMMIT=1.0.15
   - PLAT=x86_64
   - UNICODE_WIDTH=32
   - USE_CCACHE=1

--- a/config.sh
+++ b/config.sh
@@ -225,6 +225,9 @@ function pre_build {
     #    build_new_zlib
     #fi
 
+    # Remove previously installed curl.
+    rm -rf /usr/local/lib/libcurl*
+
     build_curl
 
     start_spinner

--- a/config.sh
+++ b/config.sh
@@ -226,6 +226,7 @@ function pre_build {
     #fi
 
     build_nghttp2
+    build_openssl
 
     fetch_unpack https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
 

--- a/config.sh
+++ b/config.sh
@@ -126,7 +126,7 @@ function build_curl {
         flags="$flags --with-ssl"
         build_openssl
     fi
-    fetch_unpack https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
+#    fetch_unpack https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
     (cd curl-${CURL_VERSION} \
         && if [ -z "$IS_OSX" ]; then \
         LIBS=-ldl ./configure $flags; else \
@@ -224,6 +224,8 @@ function pre_build {
     #    # Update to latest zlib for OSX build
     #    build_new_zlib
     #fi
+
+    fetch_unpack https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
 
     # Remove previously installed curl.
     rm -rf /usr/local/lib/libcurl*

--- a/config.sh
+++ b/config.sh
@@ -225,6 +225,8 @@ function pre_build {
     #    build_new_zlib
     #fi
 
+    build_nghttp2
+
     fetch_unpack https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
 
     # Remove previously installed curl.

--- a/config.sh
+++ b/config.sh
@@ -226,7 +226,11 @@ function pre_build {
     #fi
 
     build_nghttp2
-    build_openssl
+    if [ -n "$IS_OSX" ]; then
+	:
+    else  # manylinux
+        build_openssl
+    fi
 
     fetch_unpack https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
 

--- a/config.sh
+++ b/config.sh
@@ -131,7 +131,7 @@ function build_curl {
         && if [ -z "$IS_OSX" ]; then \
         LIBS=-ldl ./configure $flags; else \
         ./configure $flags; fi\
-        && make -j4 CFLAGS=-Wno-error \
+        && make -j4 \
         && make install)
     touch curl-stamp
 }

--- a/config.sh
+++ b/config.sh
@@ -117,6 +117,7 @@ function build_nghttp2 {
 
 function build_curl {
     if [ -e curl-stamp ]; then return; fi
+    build_nghttp2
     local flags="--prefix=$BUILD_PREFIX --with-nghttp2=$BUILD_PREFIX"
     if [ -n "$IS_OSX" ]; then
         return
@@ -155,14 +156,13 @@ function build_bundled_deps {
 function build_gdal {
     if [ -e gdal-stamp ]; then return; fi
 
+    build_curl
     build_jpeg
     build_libpng
     build_openjpeg
     build_jsonc
     build_proj
     build_sqlite
-    build_nghttp2
-    build_curl
     build_expat
     build_bundled_deps
 
@@ -225,8 +225,6 @@ function pre_build {
     #    build_new_zlib
     #fi
 
-    build_bundled_deps
-
     build_curl
 
     start_spinner
@@ -238,6 +236,8 @@ function pre_build {
     suppress build_expat
     suppress build_libwebp
     stop_spinner
+
+    build_bundled_deps
 
     build_gdal
 }


### PR DESCRIPTION
Removing the `-Wno-error` option that I had added a while ago (multibuild doesn't have it) seems to do the trick.

Resolves #18 